### PR TITLE
feat: Add mutation to patch episode of care

### DIFF
--- a/pkg/clinical/application/dto/enums.go
+++ b/pkg/clinical/application/dto/enums.go
@@ -12,10 +12,11 @@ const (
 type EpisodeOfCareStatusEnum string
 
 const (
-	EpisodeOfCareStatusEnumPlanned   EpisodeOfCareStatusEnum = "PLANNED"
-	EpisodeOfCareStatusEnumActive    EpisodeOfCareStatusEnum = "ACTIVE"
-	EpisodeOfCareStatusEnumFinished  EpisodeOfCareStatusEnum = "FINISHED"
-	EpisodeOfCareStatusEnumCancelled EpisodeOfCareStatusEnum = "CANCELLED"
+	EpisodeOfCareStatusEnumPlanned        EpisodeOfCareStatusEnum = "PLANNED"
+	EpisodeOfCareStatusEnumActive         EpisodeOfCareStatusEnum = "ACTIVE"
+	EpisodeOfCareStatusEnumFinished       EpisodeOfCareStatusEnum = "FINISHED"
+	EpisodeOfCareStatusEnumCancelled      EpisodeOfCareStatusEnum = "CANCELLED"
+	EpisodeOfCareStatusEnumEnteredInError EpisodeOfCareStatusEnum = "ENTERED_IN_ERROR"
 )
 
 // EncounterStatusEnum is a FHIR enum

--- a/pkg/clinical/domain/complex_types.go
+++ b/pkg/clinical/domain/complex_types.go
@@ -2467,6 +2467,16 @@ func (e EpisodeOfCareStatusEnum) IsValid() bool {
 	return false
 }
 
+// IsFinal ...
+func (e EpisodeOfCareStatusEnum) IsFinal() bool {
+	switch e {
+	case EpisodeOfCareStatusEnumFinished, EpisodeOfCareStatusEnumCancelled, EpisodeOfCareStatusEnumEnteredInError:
+		return true
+	}
+
+	return false
+}
+
 // String ...
 func (e EpisodeOfCareStatusEnum) String() string {
 	if e == EpisodeOfCareStatusEnumEnteredInError {

--- a/pkg/clinical/infrastructure/datastore/cloudhealthcare/fhir.go
+++ b/pkg/clinical/infrastructure/datastore/cloudhealthcare/fhir.go
@@ -1531,6 +1531,23 @@ func (fh StoreImpl) PatchFHIRPatient(_ context.Context, id string, input domain.
 	return resource, nil
 }
 
+// PatchFHIREpisodeOfCare patches a FHIR episode of care
+func (fh StoreImpl) PatchFHIREpisodeOfCare(_ context.Context, id string, input domain.FHIREpisodeOfCareInput) (*domain.FHIREpisodeOfCare, error) {
+	payload, err := converterandformatter.StructToMap(input)
+	if err != nil {
+		return nil, fmt.Errorf("unable to turn %s input into a map: %w", episodeOfCareResourceType, err)
+	}
+
+	resource := &domain.FHIREpisodeOfCare{}
+
+	err = fh.Dataset.PatchFHIRResource(episodeOfCareResourceType, id, payload, resource)
+	if err != nil {
+		return nil, fmt.Errorf("unable to patch %s resource: %w", episodeOfCareResourceType, err)
+	}
+
+	return resource, nil
+}
+
 // UpdateFHIREpisodeOfCare updates a fhir episode of care
 func (fh StoreImpl) UpdateFHIREpisodeOfCare(_ context.Context, fhirResourceID string, payload map[string]interface{}) (*domain.FHIREpisodeOfCare, error) {
 	if fhirResourceID == "" {

--- a/pkg/clinical/infrastructure/datastore/cloudhealthcare/mock/fhir_mock.go
+++ b/pkg/clinical/infrastructure/datastore/cloudhealthcare/mock/fhir_mock.go
@@ -67,6 +67,7 @@ type FHIRMock struct {
 	MockSearchFHIRMedicationStatementFn   func(ctx context.Context, params map[string]interface{}, tenant dto.TenantIdentifiers, pagination dto.Pagination) (*domain.FHIRMedicationStatementRelayConnection, error)
 	MockCreateFHIRPatientFn               func(ctx context.Context, input domain.FHIRPatientInput) (*domain.PatientPayload, error)
 	MockPatchFHIRPatientFn                func(ctx context.Context, id string, input domain.FHIRPatientInput) (*domain.FHIRPatient, error)
+	MockPatchFHIREpisodeOfCareFn          func(ctx context.Context, id string, input domain.FHIREpisodeOfCareInput) (*domain.FHIREpisodeOfCare, error)
 	MockUpdateFHIREpisodeOfCareFn         func(ctx context.Context, fhirResourceID string, payload map[string]interface{}) (*domain.FHIREpisodeOfCare, error)
 	MockSearchFHIRPatientFn               func(ctx context.Context, searchParams string, tenant dto.TenantIdentifiers, pagination dto.Pagination) (*domain.PatientConnection, error)
 	MockSearchPatientObservationsFn       func(ctx context.Context, patientReference, conceptID string, tenant dto.TenantIdentifiers, pagination dto.Pagination) (*domain.PagedFHIRObservations, error)
@@ -958,6 +959,26 @@ func NewFHIRMock() *FHIRMock {
 				Link:                 []*domain.FHIRPatientLink{},
 			}, nil
 		},
+		MockPatchFHIREpisodeOfCareFn: func(ctx context.Context, id string, input domain.FHIREpisodeOfCareInput) (*domain.FHIREpisodeOfCare, error) {
+			return &domain.FHIREpisodeOfCare{
+				ID:            new(string),
+				Text:          &domain.FHIRNarrative{},
+				Identifier:    []*domain.FHIRIdentifier{},
+				Status:        new(domain.EpisodeOfCareStatusEnum),
+				StatusHistory: []*domain.FHIREpisodeofcareStatushistory{},
+				Type:          []*domain.FHIRCodeableConcept{},
+				Diagnosis:     []*domain.FHIREpisodeofcareDiagnosis{},
+				Patient: &domain.FHIRReference{
+					ID: new(string),
+				},
+				ManagingOrganization: &domain.FHIRReference{},
+				Period:               &domain.FHIRPeriod{},
+				ReferralRequest:      []*domain.FHIRReference{},
+				CareManager:          &domain.FHIRReference{},
+				Team:                 []*domain.FHIRReference{},
+				Account:              []*domain.FHIRReference{},
+			}, nil
+		},
 		MockUpdateFHIREpisodeOfCareFn: func(ctx context.Context, fhirResourceID string, payload map[string]interface{}) (*domain.FHIREpisodeOfCare, error) {
 			return &domain.FHIREpisodeOfCare{
 				ID:                   new(string),
@@ -1253,6 +1274,11 @@ func (fh *FHIRMock) CreateFHIRPatient(ctx context.Context, input domain.FHIRPati
 // PatchFHIRPatient mocks the implementation for patching a fhir patient
 func (fh *FHIRMock) PatchFHIRPatient(ctx context.Context, id string, input domain.FHIRPatientInput) (*domain.FHIRPatient, error) {
 	return fh.MockPatchFHIRPatientFn(ctx, id, input)
+}
+
+// PatchFHIREpisodeOfCare mocks the implementation of patching a FHIR episode of care
+func (fh *FHIRMock) PatchFHIREpisodeOfCare(ctx context.Context, id string, input domain.FHIREpisodeOfCareInput) (*domain.FHIREpisodeOfCare, error) {
+	return fh.MockPatchFHIREpisodeOfCareFn(ctx, id, input)
 }
 
 // UpdateFHIREpisodeOfCare mocks the implementation of updating a FHIR episode of care

--- a/pkg/clinical/presentation/graph/clinical.graphql
+++ b/pkg/clinical/presentation/graph/clinical.graphql
@@ -72,6 +72,7 @@ extend type Query {
 extend type Mutation {
   # EpisodeOfCare
   createEpisodeOfCare(episodeOfCare: EpisodeOfCareInput!): EpisodeOfCare
+  patchEpisodeOfCare(id: String!, episodeOfCare: EpisodeOfCareInput!): EpisodeOfCare!
   endEpisodeOfCare(id: ID!): EpisodeOfCare
 
   # Encounter

--- a/pkg/clinical/presentation/graph/clinical.resolvers.go
+++ b/pkg/clinical/presentation/graph/clinical.resolvers.go
@@ -14,8 +14,13 @@ import (
 // CreateEpisodeOfCare is the resolver for the createEpisodeOfCare field.
 func (r *mutationResolver) CreateEpisodeOfCare(ctx context.Context, episodeOfCare dto.EpisodeOfCareInput) (*dto.EpisodeOfCare, error) {
 	r.CheckDependencies()
-
 	return r.usecases.CreateEpisodeOfCare(ctx, episodeOfCare)
+}
+
+// PatchEpisodeOfCare is the resolver for the patchEpisodeOfCare field.
+func (r *mutationResolver) PatchEpisodeOfCare(ctx context.Context, id string, episodeOfCare dto.EpisodeOfCareInput) (*dto.EpisodeOfCare, error) {
+	r.CheckDependencies()
+	return r.usecases.PatchEpisodeOfCare(ctx, id, episodeOfCare)
 }
 
 // EndEpisodeOfCare is the resolver for the endEpisodeOfCare field.

--- a/pkg/clinical/presentation/graph/generated/generated.go
+++ b/pkg/clinical/presentation/graph/generated/generated.go
@@ -168,6 +168,7 @@ type ComplexityRoot struct {
 		DeletePatient            func(childComplexity int, id string) int
 		EndEncounter             func(childComplexity int, encounterID string) int
 		EndEpisodeOfCare         func(childComplexity int, id string) int
+		PatchEpisodeOfCare       func(childComplexity int, id string, episodeOfCare dto.EpisodeOfCareInput) int
 		PatchPatient             func(childComplexity int, id string, input dto.PatientInput) int
 		RecordBloodPressure      func(childComplexity int, input dto.ObservationInput) int
 		RecordBmi                func(childComplexity int, input dto.ObservationInput) int
@@ -279,6 +280,7 @@ type ComplexityRoot struct {
 
 type MutationResolver interface {
 	CreateEpisodeOfCare(ctx context.Context, episodeOfCare dto.EpisodeOfCareInput) (*dto.EpisodeOfCare, error)
+	PatchEpisodeOfCare(ctx context.Context, id string, episodeOfCare dto.EpisodeOfCareInput) (*dto.EpisodeOfCare, error)
 	EndEpisodeOfCare(ctx context.Context, id string) (*dto.EpisodeOfCare, error)
 	StartEncounter(ctx context.Context, episodeID string) (string, error)
 	EndEncounter(ctx context.Context, encounterID string) (bool, error)
@@ -857,6 +859,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.EndEpisodeOfCare(childComplexity, args["id"].(string)), true
+
+	case "Mutation.patchEpisodeOfCare":
+		if e.complexity.Mutation.PatchEpisodeOfCare == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_patchEpisodeOfCare_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.PatchEpisodeOfCare(childComplexity, args["id"].(string), args["episodeOfCare"].(dto.EpisodeOfCareInput)), true
 
 	case "Mutation.patchPatient":
 		if e.complexity.Mutation.PatchPatient == nil {
@@ -1646,6 +1660,7 @@ var sources = []*ast.Source{
 extend type Mutation {
   # EpisodeOfCare
   createEpisodeOfCare(episodeOfCare: EpisodeOfCareInput!): EpisodeOfCare
+  patchEpisodeOfCare(id: String!, episodeOfCare: EpisodeOfCareInput!): EpisodeOfCare!
   endEpisodeOfCare(id: ID!): EpisodeOfCare
 
   # Encounter
@@ -2166,6 +2181,30 @@ func (ec *executionContext) field_Mutation_endEpisodeOfCare_args(ctx context.Con
 		}
 	}
 	args["id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_patchEpisodeOfCare_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["id"] = arg0
+	var arg1 dto.EpisodeOfCareInput
+	if tmp, ok := rawArgs["episodeOfCare"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("episodeOfCare"))
+		arg1, err = ec.unmarshalNEpisodeOfCareInput2githubᚗcomᚋsavannahghiᚋclinicalᚋpkgᚋclinicalᚋapplicationᚋdtoᚐEpisodeOfCareInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["episodeOfCare"] = arg1
 	return args, nil
 }
 
@@ -5704,6 +5743,69 @@ func (ec *executionContext) fieldContext_Mutation_createEpisodeOfCare(ctx contex
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_createEpisodeOfCare_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_patchEpisodeOfCare(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_patchEpisodeOfCare(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().PatchEpisodeOfCare(rctx, fc.Args["id"].(string), fc.Args["episodeOfCare"].(dto.EpisodeOfCareInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*dto.EpisodeOfCare)
+	fc.Result = res
+	return ec.marshalNEpisodeOfCare2ᚖgithubᚗcomᚋsavannahghiᚋclinicalᚋpkgᚋclinicalᚋapplicationᚋdtoᚐEpisodeOfCare(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_patchEpisodeOfCare(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_EpisodeOfCare_id(ctx, field)
+			case "status":
+				return ec.fieldContext_EpisodeOfCare_status(ctx, field)
+			case "patientID":
+				return ec.fieldContext_EpisodeOfCare_patientID(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type EpisodeOfCare", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_patchEpisodeOfCare_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -12932,6 +13034,15 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 				return ec._Mutation_createEpisodeOfCare(ctx, field)
 			})
 
+		case "patchEpisodeOfCare":
+
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_patchEpisodeOfCare(ctx, field)
+			})
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "endEpisodeOfCare":
 
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
@@ -14368,6 +14479,20 @@ func (ec *executionContext) marshalNDate2ᚖgithubᚗcomᚋsavannahghiᚋscalaru
 		return graphql.Null
 	}
 	return v
+}
+
+func (ec *executionContext) marshalNEpisodeOfCare2githubᚗcomᚋsavannahghiᚋclinicalᚋpkgᚋclinicalᚋapplicationᚋdtoᚐEpisodeOfCare(ctx context.Context, sel ast.SelectionSet, v dto.EpisodeOfCare) graphql.Marshaler {
+	return ec._EpisodeOfCare(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNEpisodeOfCare2ᚖgithubᚗcomᚋsavannahghiᚋclinicalᚋpkgᚋclinicalᚋapplicationᚋdtoᚐEpisodeOfCare(ctx context.Context, sel ast.SelectionSet, v *dto.EpisodeOfCare) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._EpisodeOfCare(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNEpisodeOfCareInput2githubᚗcomᚋsavannahghiᚋclinicalᚋpkgᚋclinicalᚋapplicationᚋdtoᚐEpisodeOfCareInput(ctx context.Context, v interface{}) (dto.EpisodeOfCareInput, error) {

--- a/pkg/clinical/repository/repository.go
+++ b/pkg/clinical/repository/repository.go
@@ -42,6 +42,7 @@ type FHIREpisodeOfCare interface {
 	SearchEpisodesByParam(ctx context.Context, params map[string]interface{}, tenant dto.TenantIdentifiers, pagination dto.Pagination) ([]*domain.FHIREpisodeOfCare, error)
 	GetFHIREpisodeOfCare(ctx context.Context, id string) (*domain.FHIREpisodeOfCareRelayPayload, error)
 	CreateEpisodeOfCare(ctx context.Context, episode domain.FHIREpisodeOfCareInput) (*domain.EpisodeOfCarePayload, error)
+	PatchFHIREpisodeOfCare(ctx context.Context, id string, episode domain.FHIREpisodeOfCareInput) (*domain.FHIREpisodeOfCare, error)
 	UpdateFHIREpisodeOfCare(ctx context.Context, fhirResourceID string, payload map[string]interface{}) (*domain.FHIREpisodeOfCare, error)
 	HasOpenEpisode(ctx context.Context, patient domain.FHIRPatient, tenant dto.TenantIdentifiers, pagination dto.Pagination) (bool, error)
 	OpenEpisodes(ctx context.Context, patientReference string, tenant dto.TenantIdentifiers, pagination dto.Pagination) ([]*domain.FHIREpisodeOfCare, error)

--- a/pkg/clinical/usecases/usecases.go
+++ b/pkg/clinical/usecases/usecases.go
@@ -16,6 +16,7 @@ type Clinical interface {
 
 	CreateEpisodeOfCare(ctx context.Context, input dto.EpisodeOfCareInput) (*dto.EpisodeOfCare, error)
 	GetEpisodeOfCare(ctx context.Context, id string) (*dto.EpisodeOfCare, error)
+	PatchEpisodeOfCare(ctx context.Context, id string, input dto.EpisodeOfCareInput) (*dto.EpisodeOfCare, error)
 	EndEpisodeOfCare(ctx context.Context, id string) (*dto.EpisodeOfCare, error)
 
 	CreateCondition(ctx context.Context, input dto.ConditionInput) (*dto.Condition, error)


### PR DESCRIPTION
We have states (`CANCELLED`, `PLANNED`, `ON_LEAVE`/`ONHOLD` & `ENTERED_IN_ERROR`) on Advantage that we need to transition to that aren't covered by the existing mutations (`createEpisodeOfCare` & `endEpisodeOfCare`).