### PR TITLE
feat: generate questionnaire review summary

### DIFF
--- a/pkg/clinical/application/common/defaults.go
+++ b/pkg/clinical/application/common/defaults.go
@@ -148,6 +148,15 @@ const (
 
 	// PapSmearTerminologyCode is the terminology code used to represent pap smear test.
 	PapSmearTerminologyCode = "154451"
+
+	// HighRiskCIELCode represents the CIEL code for a high-risk condition
+	HighRiskCIELCode = "166674"
+
+	// LowRiskCIELCode represents the CIEL code for a low-risk condition
+	LowRiskCIELCode = "166675"
+
+	// CIELTerminologySystem is the identity of ciel terminology system
+	CIELTerminologySystem = "https://CIELterminology.org"
 )
 
 // DefaultIdentifier assigns a patient a code to function as their

--- a/pkg/clinical/application/dto/input.go
+++ b/pkg/clinical/application/dto/input.go
@@ -172,12 +172,12 @@ type QuestionnaireResponseItemAnswer struct {
 
 // Coding : an input for a code defined by a terminology system.
 type Coding struct {
-	ID           string           `json:"id,omitempty"`
-	System       scalarutils.URI  `json:"system,omitempty"`
-	Version      string           `json:"version,omitempty"`
-	Code         scalarutils.Code `json:"code,omitempty"`
-	Display      string           `json:"display,omitempty"`
-	UserSelected bool             `json:"userSelected,omitempty"`
+	ID           string            `json:"id,omitempty"`
+	System       scalarutils.URI   `json:"system,omitempty"`
+	Version      string            `json:"version,omitempty"`
+	Code         *scalarutils.Code `json:"code,omitempty"`
+	Display      string            `json:"display,omitempty"`
+	UserSelected bool              `json:"userSelected,omitempty"`
 }
 
 // Attachment definition: input for referring to data content defined in other formats.

--- a/pkg/clinical/domain/risk_assessment.go
+++ b/pkg/clinical/domain/risk_assessment.go
@@ -49,3 +49,31 @@ type FHIRRiskAssessmentPrediction struct {
 type FHIRRiskAssessmentRelayPayload struct {
 	Resource *FHIRRiskAssessment `json:"resource,omitempty"`
 }
+
+type FHIRRiskAssessmentInput struct {
+	ID                 *string                        `json:"id,omitempty"`
+	Meta               *FHIRMetaInput                 `json:"meta,omitempty"`
+	ImplicitRules      *string                        `json:"implicitRules,omitempty"`
+	Language           *string                        `json:"language,omitempty"`
+	Text               *FHIRNarrativeInput            `json:"text,omitempty"`
+	Extension          []Extension                    `json:"extension,omitempty"`
+	ModifierExtension  []Extension                    `json:"modifierExtension,omitempty"`
+	Identifier         []FHIRIdentifierInput          `json:"identifier,omitempty"`
+	BasedOn            *FHIRReferenceInput            `json:"basedOn,omitempty"`
+	Parent             *FHIRReferenceInput            `json:"parent,omitempty"`
+	Status             ObservationStatusEnum          `json:"status,omitempty"`
+	Method             *FHIRCodeableConceptInput      `json:"method,omitempty"`
+	Code               *FHIRCodeableConceptInput      `json:"code,omitempty"`
+	Subject            FHIRReferenceInput             `json:"subject,omitempty"`
+	Encounter          *FHIRReferenceInput            `json:"encounter,omitempty"`
+	OccurrenceDateTime *string                        `json:"occurrenceDateTime,omitempty"`
+	OccurrencePeriod   *FHIRPeriodInput               `json:"occurrencePeriod,omitempty"`
+	Condition          *FHIRReferenceInput            `json:"condition,omitempty"`
+	Performer          *FHIRReferenceInput            `json:"performer,omitempty"`
+	ReasonCode         []FHIRCodeableConceptInput     `json:"reasonCode,omitempty"`
+	ReasonReference    []FHIRReferenceInput           `json:"reasonReference,omitempty"`
+	Basis              []FHIRReferenceInput           `json:"basis,omitempty"`
+	Prediction         []FHIRRiskAssessmentPrediction `json:"prediction,omitempty"`
+	Mitigation         *string                        `json:"mitigation,omitempty"`
+	Note               []FHIRAnnotationInput          `json:"note,omitempty"`
+}

--- a/pkg/clinical/infrastructure/datastore/cloudhealthcare/fhir.go
+++ b/pkg/clinical/infrastructure/datastore/cloudhealthcare/fhir.go
@@ -1776,7 +1776,7 @@ func (fh StoreImpl) CreateFHIRQuestionnaireResponse(_ context.Context, input *do
 // CreateFHIRRiskAssessment creates a RiskAssessment on FHIR
 // The RiskAssessment resource represents an assessment of the likely outcome(s) for a patient's health over
 // a period of time, considering various factors.
-func (fh StoreImpl) CreateFHIRRiskAssessment(_ context.Context, input *domain.FHIRRiskAssessment) (*domain.FHIRRiskAssessmentRelayPayload, error) {
+func (fh StoreImpl) CreateFHIRRiskAssessment(_ context.Context, input *domain.FHIRRiskAssessmentInput) (*domain.FHIRRiskAssessmentRelayPayload, error) {
 	payload, err := converterandformatter.StructToMap(input)
 	if err != nil {
 		return nil, fmt.Errorf("unable to turn %s input into a map: %w", riskAssessmentResourceType, err)

--- a/pkg/clinical/infrastructure/datastore/cloudhealthcare/fhir_unit_test.go
+++ b/pkg/clinical/infrastructure/datastore/cloudhealthcare/fhir_unit_test.go
@@ -4776,7 +4776,7 @@ func TestStoreImpl_CreateFHIRQuestionnaireResponse(t *testing.T) {
 func TestStoreImpl_CreateFHIRRiskAssessment(t *testing.T) {
 	type args struct {
 		ctx   context.Context
-		input *domain.FHIRRiskAssessment
+		input *domain.FHIRRiskAssessmentInput
 	}
 	tests := []struct {
 		name    string
@@ -4788,7 +4788,7 @@ func TestStoreImpl_CreateFHIRRiskAssessment(t *testing.T) {
 			name: "Happy Case - Successfully create a risk assessment",
 			args: args{
 				ctx:   context.Background(),
-				input: &domain.FHIRRiskAssessment{},
+				input: &domain.FHIRRiskAssessmentInput{},
 			},
 			wantErr: false,
 		},
@@ -4796,7 +4796,7 @@ func TestStoreImpl_CreateFHIRRiskAssessment(t *testing.T) {
 			name: "Sad Case - Fail to create a risk assessment",
 			args: args{
 				ctx:   context.Background(),
-				input: &domain.FHIRRiskAssessment{},
+				input: &domain.FHIRRiskAssessmentInput{},
 			},
 			wantErr: true,
 		},

--- a/pkg/clinical/infrastructure/datastore/cloudhealthcare/mock/fhir_mock.go
+++ b/pkg/clinical/infrastructure/datastore/cloudhealthcare/mock/fhir_mock.go
@@ -85,7 +85,7 @@ type FHIRMock struct {
 	MockCreateFHIRQuestionnaireFn         func(ctx context.Context, input *domain.FHIRQuestionnaire) (*domain.FHIRQuestionnaire, error)
 	MockCreateFHIRConsentFn               func(ctx context.Context, input domain.FHIRConsent) (*domain.FHIRConsent, error)
 	MockCreateFHIRQuestionnaireResponseFn func(ctx context.Context, input *domain.FHIRQuestionnaireResponse) (*domain.FHIRQuestionnaireResponse, error)
-	MockCreateFHIRRiskAssessmentFn        func(ctx context.Context, input *domain.FHIRRiskAssessment) (*domain.FHIRRiskAssessmentRelayPayload, error)
+	MockCreateFHIRRiskAssessmentFn        func(ctx context.Context, input *domain.FHIRRiskAssessmentInput) (*domain.FHIRRiskAssessmentRelayPayload, error)
 	MockGetFHIRQuestionnaireFn            func(ctx context.Context, id string) (*domain.FHIRQuestionnaireRelayPayload, error)
 }
 
@@ -1898,11 +1898,62 @@ func NewFHIRMock() *FHIRMock {
 			return &input, nil
 		},
 		MockCreateFHIRQuestionnaireResponseFn: func(ctx context.Context, input *domain.FHIRQuestionnaireResponse) (*domain.FHIRQuestionnaireResponse, error) {
-			return input, nil
+			ID := gofakeit.UUID()
+			highScore := 8
+			lowScore := 1
+			return &domain.FHIRQuestionnaireResponse{
+				ID: &ID,
+				Item: []domain.FHIRQuestionnaireResponseItem{
+					{
+						LinkID: "symptoms",
+						Answer: []domain.FHIRQuestionnaireResponseItemAnswer{},
+						Item: []domain.FHIRQuestionnaireResponseItem{
+							{
+								ID:                new(string),
+								Extension:         []domain.FHIRExtension{},
+								ModifierExtension: []domain.FHIRExtension{},
+								LinkID:            "symptoms-score",
+								Definition:        new(string),
+								Text:              new(string),
+								Answer: []domain.FHIRQuestionnaireResponseItemAnswer{
+									{
+										ValueInteger: &highScore,
+									},
+								},
+								Item: []domain.FHIRQuestionnaireResponseItem{},
+							},
+						},
+					},
+					{
+						LinkID: "risk-factors",
+						Answer: []domain.FHIRQuestionnaireResponseItemAnswer{},
+						Item: []domain.FHIRQuestionnaireResponseItem{
+							{
+								ID:                new(string),
+								Extension:         []domain.FHIRExtension{},
+								ModifierExtension: []domain.FHIRExtension{},
+								LinkID:            "risk-factors-score",
+								Definition:        new(string),
+								Text:              new(string),
+								Answer: []domain.FHIRQuestionnaireResponseItemAnswer{
+									{
+										ValueInteger: &lowScore,
+									},
+								},
+								Item: []domain.FHIRQuestionnaireResponseItem{},
+							},
+						},
+					},
+				},
+			}, nil
 		},
-		MockCreateFHIRRiskAssessmentFn: func(ctx context.Context, input *domain.FHIRRiskAssessment) (*domain.FHIRRiskAssessmentRelayPayload, error) {
+		MockCreateFHIRRiskAssessmentFn: func(ctx context.Context, input *domain.FHIRRiskAssessmentInput) (*domain.FHIRRiskAssessmentRelayPayload, error) {
+			riskAssessment := &domain.FHIRRiskAssessment{
+				ID:   new(string),
+				Meta: &domain.FHIRMeta{},
+			}
 			return &domain.FHIRRiskAssessmentRelayPayload{
-				Resource: input,
+				Resource: riskAssessment,
 			}, nil
 		},
 		MockGetFHIRQuestionnaireFn: func(ctx context.Context, id string) (*domain.FHIRQuestionnaireRelayPayload, error) {
@@ -2255,7 +2306,7 @@ func (fh *FHIRMock) CreateFHIRQuestionnaireResponse(ctx context.Context, input *
 }
 
 // CreateFHIRRiskAssessment mocks the method for creating a fhir risk assessment record
-func (fh *FHIRMock) CreateFHIRRiskAssessment(ctx context.Context, input *domain.FHIRRiskAssessment) (*domain.FHIRRiskAssessmentRelayPayload, error) {
+func (fh *FHIRMock) CreateFHIRRiskAssessment(ctx context.Context, input *domain.FHIRRiskAssessmentInput) (*domain.FHIRRiskAssessmentRelayPayload, error) {
 	return fh.MockCreateFHIRRiskAssessmentFn(ctx, input)
 }
 

--- a/pkg/clinical/presentation/graph/generated/generated.go
+++ b/pkg/clinical/presentation/graph/generated/generated.go
@@ -8138,9 +8138,9 @@ func (ec *executionContext) _Coding_code(ctx context.Context, field graphql.Coll
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(scalarutils.Code)
+	res := resTmp.(*scalarutils.Code)
 	fc.Result = res
-	return ec.marshalOCode2githubᚗcomᚋsavannahghiᚋscalarutilsᚐCode(ctx, field.Selections, res)
+	return ec.marshalOCode2ᚖgithubᚗcomᚋsavannahghiᚋscalarutilsᚐCode(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Coding_code(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -28910,7 +28910,7 @@ func (ec *executionContext) unmarshalInputCodingInput(ctx context.Context, obj i
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("code"))
-			data, err := ec.unmarshalOCode2githubᚗcomᚋsavannahghiᚋscalarutilsᚐCode(ctx, v)
+			data, err := ec.unmarshalOCode2ᚖgithubᚗcomᚋsavannahghiᚋscalarutilsᚐCode(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -35070,6 +35070,22 @@ func (ec *executionContext) unmarshalOCode2githubᚗcomᚋsavannahghiᚋscalarut
 }
 
 func (ec *executionContext) marshalOCode2githubᚗcomᚋsavannahghiᚋscalarutilsᚐCode(ctx context.Context, sel ast.SelectionSet, v scalarutils.Code) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) unmarshalOCode2ᚖgithubᚗcomᚋsavannahghiᚋscalarutilsᚐCode(ctx context.Context, v interface{}) (*scalarutils.Code, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var res = new(scalarutils.Code)
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOCode2ᚖgithubᚗcomᚋsavannahghiᚋscalarutilsᚐCode(ctx context.Context, sel ast.SelectionSet, v *scalarutils.Code) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
 	return v
 }
 

--- a/pkg/clinical/repository/repository.go
+++ b/pkg/clinical/repository/repository.go
@@ -130,5 +130,5 @@ type FHIRQuestionnaireResponse interface {
 }
 
 type FHIRRiskAssessment interface {
-	CreateFHIRRiskAssessment(_ context.Context, input *domain.FHIRRiskAssessment) (*domain.FHIRRiskAssessmentRelayPayload, error)
+	CreateFHIRRiskAssessment(_ context.Context, input *domain.FHIRRiskAssessmentInput) (*domain.FHIRRiskAssessmentRelayPayload, error)
 }

--- a/pkg/clinical/usecases/clinical/riskassessment.go
+++ b/pkg/clinical/usecases/clinical/riskassessment.go
@@ -1,0 +1,79 @@
+package clinical
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/savannahghi/clinical/pkg/clinical/domain"
+	"github.com/savannahghi/scalarutils"
+)
+
+// RecordRiskAssessment records a risk assessment based on the provided parameters.
+func (c *UseCasesClinicalImpl) RecordRiskAssessment(
+	ctx context.Context,
+	encounterID string,
+	questionnaireResponseID string,
+	outcome domain.FHIRCodeableConcept,
+) (*domain.FHIRRiskAssessment, error) {
+	encounter, err := c.infrastructure.FHIR.GetFHIREncounter(ctx, encounterID)
+	if err != nil {
+		return nil, err
+	}
+
+	if encounter.Resource.Status == domain.EncounterStatusEnumFinished {
+		return nil, fmt.Errorf("cannot record a risk assessment in a finished encounter")
+	}
+
+	patientID := encounter.Resource.Subject.ID
+	patientReference := fmt.Sprintf("Patient/%s", *patientID)
+
+	encounterReference := fmt.Sprintf("Encounter/%s", *encounter.Resource.ID)
+
+	instant := scalarutils.Instant(time.Now().Format(time.RFC3339))
+
+	riskAssessment := domain.FHIRRiskAssessmentInput{
+		Status: domain.ObservationStatusEnumFinal,
+		Code:   &domain.FHIRCodeableConceptInput{},
+		Subject: domain.FHIRReferenceInput{
+			ID:        encounter.Resource.Subject.ID,
+			Reference: &patientReference,
+			Display:   encounter.Resource.Subject.Display,
+		},
+		Encounter: &domain.FHIRReferenceInput{
+			ID:        encounter.Resource.ID,
+			Reference: &encounterReference,
+		},
+		OccurrenceDateTime: (*string)(&instant),
+		Prediction: []domain.FHIRRiskAssessmentPrediction{
+			{
+				Outcome: &outcome,
+			},
+		},
+	}
+
+	if questionnaireResponseID != "" {
+		questionnaireResponseReference := fmt.Sprintf("QuestionnaireResponse/%s", questionnaireResponseID)
+		riskAssessment.Basis = []domain.FHIRReferenceInput{
+			{
+				Reference: &questionnaireResponseReference,
+			},
+		}
+	}
+
+	tags, err := c.GetTenantMetaTags(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	riskAssessment.Meta = &domain.FHIRMetaInput{
+		Tag: tags,
+	}
+
+	assessment, err := c.infrastructure.FHIR.CreateFHIRRiskAssessment(ctx, &riskAssessment)
+	if err != nil {
+		return nil, err
+	}
+
+	return assessment.Resource, nil
+}

--- a/pkg/clinical/usecases/clinical/riskassessment_test.go
+++ b/pkg/clinical/usecases/clinical/riskassessment_test.go
@@ -1,0 +1,138 @@
+package clinical_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/brianvoe/gofakeit"
+	"github.com/savannahghi/clinical/pkg/clinical/application/dto"
+	fakeExtMock "github.com/savannahghi/clinical/pkg/clinical/application/extensions/mock"
+	"github.com/savannahghi/clinical/pkg/clinical/domain"
+	"github.com/savannahghi/clinical/pkg/clinical/infrastructure"
+	fakeFHIRMock "github.com/savannahghi/clinical/pkg/clinical/infrastructure/datastore/cloudhealthcare/mock"
+	fakeOCLMock "github.com/savannahghi/clinical/pkg/clinical/infrastructure/services/openconceptlab/mock"
+	fakePubSubMock "github.com/savannahghi/clinical/pkg/clinical/infrastructure/services/pubsub/mock"
+	fakeUploadMock "github.com/savannahghi/clinical/pkg/clinical/infrastructure/services/upload/mock"
+	clinicalUsecase "github.com/savannahghi/clinical/pkg/clinical/usecases/clinical"
+)
+
+func TestUseCasesClinicalImpl_RecordRiskAssessment(t *testing.T) {
+	type args struct {
+		ctx                     context.Context
+		encounterID             string
+		questionnaireResponseID string
+		outcome                 domain.FHIRCodeableConcept
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *domain.FHIRRiskAssessment
+		wantErr bool
+	}{
+		{
+			name: "Happy Case - Successfully record a risk assessment",
+			args: args{
+				ctx:                     context.Background(),
+				encounterID:             gofakeit.UUID(),
+				questionnaireResponseID: gofakeit.UUID(),
+				outcome:                 domain.FHIRCodeableConcept{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Sad Case - Fail to get encounter",
+			args: args{
+				ctx:                     context.Background(),
+				encounterID:             gofakeit.UUID(),
+				questionnaireResponseID: gofakeit.UUID(),
+				outcome:                 domain.FHIRCodeableConcept{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Sad Case - Attempt to record risk assessment in a finished encounter",
+			args: args{
+				ctx:                     context.Background(),
+				encounterID:             gofakeit.UUID(),
+				questionnaireResponseID: gofakeit.UUID(),
+				outcome:                 domain.FHIRCodeableConcept{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Sad Case - fail to get tenant tags",
+			args: args{
+				ctx:                     context.Background(),
+				encounterID:             gofakeit.UUID(),
+				questionnaireResponseID: gofakeit.UUID(),
+				outcome:                 domain.FHIRCodeableConcept{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Sad Case - fail to create fhir risk assessment",
+			args: args{
+				ctx:                     context.Background(),
+				encounterID:             gofakeit.UUID(),
+				questionnaireResponseID: gofakeit.UUID(),
+				outcome:                 domain.FHIRCodeableConcept{},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeExt := fakeExtMock.NewFakeBaseExtensionMock()
+			fakeFHIR := fakeFHIRMock.NewFHIRMock()
+			fakeOCL := fakeOCLMock.NewFakeOCLMock()
+			fakePubSub := fakePubSubMock.NewPubSubServiceMock()
+
+			fakeUpload := fakeUploadMock.NewFakeUploadMock()
+
+			infra := infrastructure.NewInfrastructureInteractor(fakeExt, fakeFHIR, fakeOCL, fakeUpload, fakePubSub)
+			c := clinicalUsecase.NewUseCasesClinicalImpl(infra)
+
+			if tt.name == "Sad Case - Fail to get encounter" {
+				fakeFHIR.MockGetFHIREncounterFn = func(ctx context.Context, id string) (*domain.FHIREncounterRelayPayload, error) {
+					return nil, fmt.Errorf("failed to get fhir encounter")
+				}
+			}
+
+			if tt.name == "Sad Case - Attempt to record risk assessment in a finished encounter" {
+				fakeFHIR.MockGetFHIREncounterFn = func(ctx context.Context, id string) (*domain.FHIREncounterRelayPayload, error) {
+					return &domain.FHIREncounterRelayPayload{
+						Resource: &domain.FHIREncounter{
+							Status: "finished",
+						},
+					}, nil
+				}
+			}
+
+			if tt.name == "Sad Case - fail to get tenant tags" {
+				fakeExt.MockGetTenantIdentifiersFn = func(ctx context.Context) (*dto.TenantIdentifiers, error) {
+					return nil, fmt.Errorf("an error occurred")
+				}
+			}
+
+			if tt.name == "Sad Case - fail to create fhir risk assessment" {
+				fakeFHIR.MockCreateFHIRRiskAssessmentFn = func(ctx context.Context, input *domain.FHIRRiskAssessmentInput) (*domain.FHIRRiskAssessmentRelayPayload, error) {
+					return nil, fmt.Errorf("failed to create fhir risk assessment")
+				}
+			}
+
+			got, err := c.RecordRiskAssessment(tt.args.ctx, tt.args.encounterID, tt.args.questionnaireResponseID, tt.args.outcome)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UseCasesClinicalImpl.RecordRiskAssessment() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				if got == nil {
+					t.Errorf("expected a response but got %v", got)
+					return
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces a feature that generates a questionnaire review summary Workflow:
1. User answers a questionnaire and a questionnaire response is generated
2. Save the response in cloud healthcare
3. Generate a review summary i.e Determine the patient's risk factors based on the give algorithms
4. Record the risk assessment under the RiskAssessment FHIR resource type - Prediction is either `High Risk` or `Low Risk`

# Review Checklist

[![Bugs](https://img.shields.io/badge/BugFixes-0-red.svg?style=for-the-badge)](https://shields.io/)
[![Features](https://img.shields.io/badge/Features-0-orange?style=for-the-badge)](https://shields.io/)
[![Tests](https://img.shields.io/badge/Tests-0-success.svg?style=for-the-badge)](https://shields.io/)

#### Summary*

- [ ] fix: Bug fix for `Add the items tackled here as checklists`
- [x] feat: Completed task
- [ ] chore: Incomplete task
  - [ ] test: Sub-task 1


#### Structure*

- [ ] The Pull Request has a `proper` title that conforms to our [MR title standards](https://gist.github.com/mikepea/863f63d6e37281e329f8)
- [ ] The Pull Request has one commit, and if there are more than one, they should be squashed
- [ ] The commit should have a proper title and a short description
- [ ] The commit must be signed off
- [ ] Unused imports are not present
- [ ] Dead code is not present
- [ ] Ensure dry running library to confirm changes

#### Tests

- [ ] Proper and high quality unit, integration and acceptance(if applicable) tests have been written
- [ ] The coverage threshold should not be lowered

### Sign off*

- [ ] All comments have been resolved by the reviewers
- [ ] Approved by Czar {replace_with_czar_name}
- [ ] Signed off by second reviewer {replace_with_name}
- [ ] Ensure all checks are done before merging :warning:
- [ ] All PRs needs to be signed before merging :warning:

#### N/B:

- Add a checklist if more than one item is done.
- Add screenshots and/or images where necessary
- Indicate any breakages caused in the UI :exclamation:
- Where necessary, indicate which issue the Pull Request solves (Closes #)
- Any new files are updated in the folder structure in the [README](../../README.md)